### PR TITLE
Br 20210722 1432

### DIFF
--- a/include/iotconnect_common.h
+++ b/include/iotconnect_common.h
@@ -20,10 +20,10 @@ char *iotcl_strdup(const char *str);
 const char *iotcl_to_iso_timestamp(time_t timestamp);
 
 // NOTE: This function is not thread-safe
-const char *iotcl_iso_timestamp_now();
+const char *iotcl_iso_timestamp_now(void);
 
 // Internal function
-void iotcl_oom_error();
+void iotcl_oom_error(void);
 
 #ifdef __cplusplus
 }

--- a/include/iotconnect_lib.h
+++ b/include/iotconnect_lib.h
@@ -47,7 +47,7 @@ bool iotcl_init(IotclConfig *c);
 
 IotclConfig *iotcl_get_config(void);
 
-void iotcl_deinit();
+void iotcl_deinit(void);
 
 #ifdef __cplusplus
 }

--- a/include/iotconnect_telemetry.h
+++ b/include/iotconnect_telemetry.h
@@ -28,7 +28,7 @@ typedef struct IotclMessageHandleTag *IotclMessageHandle;
  * This handle can be used to add data to the message.
  * The handle cannot be re-used and should be destroyed to free up resources, once the message is sent.
  */
-IotclMessageHandle iotcl_telemetry_create();
+IotclMessageHandle iotcl_telemetry_create(void);
 
 /*
  * Destroys the IoTConnect message handle.

--- a/src/iotconnect_common.c
+++ b/src/iotconnect_common.c
@@ -19,7 +19,7 @@ const char *iotcl_to_iso_timestamp(time_t timestamp) {
     return to_iso_timestamp(&timestamp);
 }
 
-const char *iotcl_iso_timestamp_now() {
+const char *iotcl_iso_timestamp_now(void) {
     return to_iso_timestamp(NULL);
 }
 

--- a/src/iotconnect_event.c
+++ b/src/iotconnect_event.c
@@ -204,7 +204,7 @@ char *iotcl_clone_download_url(IotclEventData data, size_t index) {
         return NULL;
     }
     if ((size_t) cJSON_GetArraySize(urls) > index) {
-        cJSON *url = cJSON_GetArrayItem(urls, index);
+        cJSON *url = cJSON_GetArrayItem(urls, (int)index);
         if (is_valid_string(url)) {
             return iotcl_strdup(url->valuestring);
         } else if (cJSON_IsObject(url)) {

--- a/src/iotconnect_lib.c
+++ b/src/iotconnect_lib.c
@@ -47,7 +47,7 @@ IotclConfig *iotcl_get_config() {
     return &config;
 }
 
-void iotcl_deinit() {
+void iotcl_deinit(void) {
     config_is_valid = false;
 
     memset(&config, 0, sizeof(config));

--- a/src/iotconnect_telemetry.c
+++ b/src/iotconnect_telemetry.c
@@ -97,7 +97,7 @@ static cJSON *setup_telemetry_object(IotclMessageHandle message) {
     return NULL;
 }
 
-IotclMessageHandle iotcl_telemetry_create() {
+IotclMessageHandle iotcl_telemetry_create(void) {
     cJSON *sdk_array = NULL;
     IotclConfig *config = iotcl_get_config();
     if (!config) return NULL;


### PR DESCRIPTION
**iotconnect_common.h**
- Added "void" to iotcl_iso_timestamp_now() to suppress compilation warning.
- Added "void" to iotcl_oom_error() to suppress compilation warning.

**iotconnect_telemetry.h**
- Added "void" to iotcl_telemetry_create() to suppress compilation warning.
 
**iotconnect_lib.h**
- Added "void" to iotcl_deinit() to suppress compilation warning.

**iotconnect_common.c**
- Added "void" to iotcl_iso_timestamp_now() to suppress compilation warning.

**iotconnect_telemetry.c**
- Added "void" to iotcl_telemetry_create() to suppress compilation warning.

**iotconnect_lib.c**
- Added "void" to iotcl_deinit() to suppress compilation warning.

** iotconnect_event.c**
- Cast "size_t" type variable *index* to "int" type to suppress compilation warning.