### PR TITLE
Add Dynamic Device Identity Management protocol support

### DIFF
--- a/include/iotconnect_device_identity.h
+++ b/include/iotconnect_device_identity.h
@@ -1,0 +1,86 @@
+/* Copyright (C) 2022 Avnet - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ * Authors: Nikola Markovic <nikola.markovic@avnet.com> et al.
+ */
+
+/*
+ * This file contains functions that aid in developing SDKs for DDIM support
+ *
+ * DDIM Sequence:
+ * 1) The device presents the bootstrap certificate to the server
+ * 2) The server responds with certificate ID (cid), random number string (rn), and common name
+ * for the operational certificate for which the device needs to create a CSR
+ * 3) The device signs the CID string, the random number string and the CSR (binary)
+ * with SHA265 hash using the operational identity (CSR's) private key.
+ * 4) The device sends the CSR and the signature to the server.
+ * 5) The server responds with the operational certificate that the device can use to connect
+ * to the operational IoTHub.
+ * 5) The device writes the newly obtained certificate into the secure element's storage.
+ * 6) The device confirms that was able to store the certificate by exiting the "ack" server endpoint with
+ * the CID obtained in step #2.
+ */
+
+#ifndef IOTCONNECT_DEVICE_IDENTITY_H
+#define IOTCONNECT_DEVICE_IDENTITY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+ 
+
+typedef struct IotclDdimAuthRequest {
+	char *bcert; // bootstrap certificate
+	char *fmt; // format "hex" (der) by default
+} IotclDdimAuthRequest;
+
+typedef struct IotclDdimAuthResponse {
+	char *rn; // random number
+	char *cn; // common name
+	char *cid; // certificate id
+	char *message; // error message
+	int ec; // error code
+} IotclDdimAuthResponse;
+
+typedef struct IotclDdimSignRequest {
+	char *sig; // error message
+	char *csr; // csr
+	char *fmt; // format "hex" (der) by default
+} IotclDdimSignRequest;
+
+typedef struct IotclDdimSignResponse {
+	char *cert; // operational cert
+	char *message; // error message
+	int ec; // error code
+} IotclDdimSignResponse;
+
+typedef struct IotclDdimAckRequest {
+	char *cid;
+} IotclDdimAckRequest;
+
+typedef struct IotclDdimAckResponse {
+	char *message; // error message
+	int ec; // error code
+} IotclDdimAckResponse;
+
+const char * iotcl_ddim_auth_request_create_serialized_string(IotclDdimAuthRequest* request);
+const char * iotcl_ddim_sign_request_create_serialized_string(IotclDdimSignRequest* request);
+const char * iotcl_ddim_ack_request_create_serialized_string(IotclDdimAckRequest* request);
+
+// Free a string returned by any of the *create_serialized calls
+void iotcl_ddim_destory_serialized_string(const char *serialized_string);
+
+IotclDdimAuthResponse * iotcl_ddim_parse_auth_response(const char* response_data);
+void iotcl_ddim_free_auth_response(IotclDdimAuthResponse *response);
+
+IotclDdimSignResponse* iotcl_ddim_parse_sign_response(const char* response_data);
+void iotcl_ddim_free_sign_response(IotclDdimSignResponse *response);
+
+IotclDdimAckResponse* iotcl_ddim_parse_ack_response(const char* response_data);
+void iotcl_ddim_free_ack_response(IotclDdimAckResponse *response);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //IOTCONNECT_DEVICE_IDENTITY_H

--- a/include/iotconnect_discovery_v3.h
+++ b/include/iotconnect_discovery_v3.h
@@ -1,0 +1,36 @@
+/* Copyright (C) 2022 Avnet - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ * Authors: Nikola Markovic <nikola.markovic@avnet.com> et al.
+ */
+
+/*
+ * This file contains functions that aid in developing SDKs for specific platforms or help implement custom approaches
+ * for to IoTConnect discovery HTTP API.
+ */
+
+#ifndef IOTCONNECT_DISCOVERY_V3_H
+#define IOTCONNECT_DISCOVERY_V3_H
+
+#define DISCOVERY_V3_HOST_NAME "discovery.iotconnect.io"
+#define DISCOVERY_V3_RESOURCE_FORMAT "/api/v3.1/dsdk/cpId/%s/env/%s"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct IotclDiscoveryV3Response {
+	int ec; // error code. 0 = success.
+	char *bu; // Agent Host base URL. Append resource path to this returned URL
+	char *message; // message or error message
+} IotclDiscoveryV3Response;
+
+IotclDiscoveryV3Response * iotcl_parse_discovery_v3_response(const char* response_data);
+
+void iotcl_free_discovery_v3_response(IotclDiscoveryV3Response *response);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //IOTCONNECT_DISCOVERY_V3_H

--- a/src/iotconnect_device_identity.c
+++ b/src/iotconnect_device_identity.c
@@ -1,0 +1,181 @@
+/* Copyright (C) 2020 Avnet - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ * Authors: Nikola Markovic <nikola.markovic@avnet.com> et al.
+ */
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include <string.h>
+#include <cJSON.h>
+
+#include "iotconnect_common.h"
+#include "iotconnect_device_identity.h"
+
+static int get_numeric_value_or_default(cJSON *cjson, const char *value_name, int default_value) {
+	cJSON* tmp_value = cJSON_GetObjectItem(cjson, value_name);
+	if (!tmp_value || !cJSON_IsNumber(tmp_value)) {
+		return default_value;
+	}
+	return cJSON_GetNumberValue(tmp_value);
+}
+static char *safe_get_string_and_strdup(cJSON *cjson, const char *value_name) {
+    cJSON *value = cJSON_GetObjectItem(cjson, value_name);
+    if (!value) {
+        return NULL;
+    }
+    const char *str_value = cJSON_GetStringValue(value);
+    if (!str_value) {
+        return NULL;
+    }
+    return iotcl_strdup(str_value);
+}
+
+const char * iotcl_ddim_auth_request_create_serialized_string(IotclDdimAuthRequest* request) {
+	const char* ret = NULL;
+    cJSON *request_object = cJSON_CreateObject();
+    if (!request_object) return NULL;
+    if (!cJSON_AddStringToObject(request_object, "fmt", request->fmt)) goto cleanup;;
+    if (!cJSON_AddStringToObject(request_object, "bcert", request->bcert)) goto cleanup;
+    ret = cJSON_PrintUnformatted(request_object);
+
+    cleanup:
+    cJSON_free(request_object);
+    return ret;
+}
+
+
+const char * iotcl_ddim_sign_request_create_serialized_string(IotclDdimSignRequest* request) {
+    const char* ret = NULL;
+    cJSON *request_object = cJSON_CreateObject();
+	if (!request_object) return NULL;
+    if(!cJSON_AddStringToObject(request_object, "fmt", request->fmt)) goto cleanup;
+    if(!cJSON_AddStringToObject(request_object, "sig", request->sig)) goto cleanup;
+    if(!cJSON_AddStringToObject(request_object, "csr", request->csr)) goto cleanup;;
+    ret = cJSON_PrintUnformatted(request_object);
+
+    cleanup:
+    cJSON_free(request_object);
+    return ret;
+}
+
+const char * iotcl_ddim_ack_request_create_serialized_string(IotclDdimAckRequest* request) {
+	const char* ret = NULL;
+    cJSON *request_object = cJSON_CreateObject();
+    if (!request_object) return NULL;
+    if (!cJSON_AddStringToObject(request_object, "cid", request->cid)) goto cleanup;
+    ret = cJSON_PrintUnformatted(request_object);
+
+    cleanup:
+    cJSON_free(request_object);
+    return ret;
+}
+
+
+void iotcl_ddim_destory_serialized_string(const char *serialized_string) {
+    cJSON_free((char *) serialized_string);
+}
+
+IotclDdimAuthResponse * iotcl_ddim_parse_auth_response(const char* response_data) {
+    IotclDdimAuthResponse *response = (IotclDdimAuthResponse *) calloc(1, sizeof(IotclDdimAuthResponse));
+    if (NULL == response) {
+        return NULL;
+    }
+
+    cJSON *json_root = cJSON_Parse(response_data);
+    if (!json_root) {
+        response->message = "IOTCL Parsing Error";
+        return response;
+    }
+    response->rn = safe_get_string_and_strdup(json_root, "rn");
+    response->cn = safe_get_string_and_strdup(json_root, "cn");
+    response->cid = safe_get_string_and_strdup(json_root, "cid");
+    response->message = safe_get_string_and_strdup(json_root, "message");
+    response->ec = get_numeric_value_or_default(json_root, "ec", -1);
+
+    if (!response->rn || !response->cn || !response->cid || !response->message) {
+    	// out of ram possibly. The fields re required.
+    	iotcl_ddim_free_auth_response(response);
+    	response = NULL;
+    }
+
+    // we have duplicated the strings, so we can now free the result
+    cJSON_Delete(json_root);
+    return response;
+}
+IotclDdimSignResponse* iotcl_ddim_parse_sign_response(const char* response_data) {
+	IotclDdimSignResponse *response = (IotclDdimSignResponse *) calloc(1, sizeof(IotclDdimSignResponse));
+    if (NULL == response) {
+        return NULL;
+    }
+
+    cJSON *json_root = cJSON_Parse(response_data);
+    if (!json_root) {
+        response->message = "IOTCL Parsing Error";
+        return response;
+    }
+    response->cert = safe_get_string_and_strdup(json_root, "cert");
+    response->message = safe_get_string_and_strdup(json_root, "message");
+    response->ec = get_numeric_value_or_default(json_root, "ec", -1);
+
+    if (!response->cert || !response->message) {
+    	// out of ram possibly. The fields re required.
+    	iotcl_ddim_free_sign_response(response);
+    	response = NULL;
+    }
+    // we have duplicated the strings, so we can now free the result
+    cJSON_Delete(json_root);
+    return response;
+}
+
+IotclDdimAckResponse* iotcl_ddim_parse_ack_response(const char* response_data) {
+	IotclDdimAckResponse *response = (IotclDdimAckResponse *) calloc(1, sizeof(IotclDdimAckResponse));
+    if (NULL == response) {
+        return NULL;
+    }
+
+    cJSON *json_root = cJSON_Parse(response_data);
+    if (!json_root) {
+        response->message = "IOTCL Parsing Error";
+        return response;
+    }
+    response->message = safe_get_string_and_strdup(json_root, "message");
+    response->ec = get_numeric_value_or_default(json_root, "ec", -1);
+
+    // we have duplicated the strings, so we can now free the result
+    cJSON_Delete(json_root);
+    return response;
+}
+
+
+void iotcl_ddim_free_auth_response(IotclDdimAuthResponse *response) {
+    if (response) {
+        free(response->rn);
+        free(response->cn);
+        free(response->cid);
+        if (response->message) {
+            free(response->message);
+        }
+        free(response);
+    }
+}
+
+void iotcl_ddim_free_sign_response(IotclDdimSignResponse *response) {
+    if (response) {
+        free(response->cert);
+        if (response->message) {
+            free(response->message);
+        }
+        free(response);
+    }
+}
+
+void iotcl_ddim_free_ack_response(IotclDdimAckResponse *response) {
+    if (response) {
+        if (response->message) {
+            free(response->message);
+        }
+        free(response);
+    }
+}

--- a/src/iotconnect_discovery_v3.c
+++ b/src/iotconnect_discovery_v3.c
@@ -1,0 +1,62 @@
+//
+// Copyright: Avnet, Softweb Inc. 2022
+// Created by Nik Markovic <nikola.markovic@avnet.com> on 5/15/22.
+//
+
+#include <stddef.h>
+#include <stdlib.h>
+#include "cJSON.h"
+#include "iotconnect_common.h"
+#include "iotconnect_discovery_v3.h"
+
+static char *safe_get_string_and_strdup(cJSON *cjson, const char *value_name) {
+    cJSON *value = cJSON_GetObjectItem(cjson, value_name);
+    if (!value) {
+        return NULL;
+    }
+    const char *str_value = cJSON_GetStringValue(value);
+    if (!str_value) {
+        return NULL;
+    }
+    return iotcl_strdup(str_value);
+}
+
+IotclDiscoveryV3Response * iotcl_parse_discovery_v3_response(const char* response_data) {
+	IotclDiscoveryV3Response *response = (IotclDiscoveryV3Response *) calloc(1, sizeof(IotclDiscoveryV3Response));
+    if (NULL == response) {
+        return NULL;
+    }
+    response->ec = -1;
+    cJSON *json_root = cJSON_Parse(response_data);
+    if (!json_root) {
+        response->message = iotcl_strdup("IOTCL Parsing Error");
+        cJSON_Delete(json_root);
+        return response;
+    }
+    cJSON *json_data = cJSON_GetObjectItem(json_root, "d");
+    if (!json_data) {
+    	response->message = iotcl_strdup("IOTCL: Discovery data object is missing");
+        cJSON_Delete(json_root);
+    	return response;
+    }
+    response->ec = cJSON_GetNumberValue(cJSON_GetObjectItem(json_data, "ec"));
+    response->bu = safe_get_string_and_strdup(json_data, "bu");
+    if (!response->bu) {
+        response->message = iotcl_strdup("IOTCL: Discovery base URL is NULL. Out of memory?");
+        cJSON_Delete(json_root);
+        return response;
+    }
+    response->message = safe_get_string_and_strdup(json_root, "message");
+
+    // we have duplicated strings, so we can now free the result
+    cJSON_Delete(json_root);
+    return response;
+}
+
+void iotcl_free_discovery_v3_response(IotclDiscoveryV3Response *response) {
+	if (response) {
+		free(response->bu);
+		free(response->message);
+		free(response);
+	}
+}


### PR DESCRIPTION
Add Dynamic Device Identity Management support.

 DDIM Sequence:
* The device presents the bootstrap certificate to the server
* The server responds with certificate ID (cid), random number string (rn), and common name for the operational certificate for which the device needs to create a CSR
* The device signs the CID string, the random number string and the CSR (binary) with SHA265 hash using the operational identity (CSR's) private key.
* The device sends the CSR and the signature to the server.
* The server responds with the operational certificate that the device can use to connect  to the operational IoTHub.
* The device writes the newly obtained certificate into the secure element's storage.
* The device confirms that was able to store the certificate by exiting the "ack" server endpoint with the CID obtained in the second step.
