### PR TITLE
"0 == strlen(c->device.env)" is being checked multiple times in the s…

### DIFF
--- a/src/iotconnect_lib.c
+++ b/src/iotconnect_lib.c
@@ -18,7 +18,7 @@ bool iotcl_init(IotclConfig *c) {
     iotcl_deinit();
     if (
             !c || !c->device.env || !c->device.cpid || !c->device.duid ||
-            0 == strlen(c->device.env) || 0 == strlen(c->device.env) || 0 == strlen(c->device.env)
+            0 == strlen(c->device.env) || 0 == strlen(c->device.cpid) || 0 == strlen(c->device.duid)
             ) {
         IOTCL_LOG ("IotConnectLib_Configure: configuration parameters missing" IOTCL_NL);
         return false;


### PR DESCRIPTION
…ame if statement.

cppcheck flagged this as multiple checks for the same condition.
From the code it looks likely that this is a copy/paste and cpid/duid might be intended to be checked.