### PR TITLE
Use (void) rather than () to indicate that functions take no arguments.

### DIFF
--- a/include/iotconnect_common.h
+++ b/include/iotconnect_common.h
@@ -20,10 +20,10 @@ char *iotcl_strdup(const char *str);
 const char *iotcl_to_iso_timestamp(time_t timestamp);
 
 // NOTE: This function is not thread-safe
-const char *iotcl_iso_timestamp_now();
+const char *iotcl_iso_timestamp_now(void);
 
 // Internal function
-void iotcl_oom_error();
+void iotcl_oom_error(void);
 
 #ifdef __cplusplus
 }

--- a/include/iotconnect_lib.h
+++ b/include/iotconnect_lib.h
@@ -45,7 +45,7 @@ bool iotcl_init(IotclConfig *c);
 
 IotclConfig *iotcl_get_config(void);
 
-void iotcl_deinit();
+void iotcl_deinit(void);
 
 #ifdef __cplusplus
 }

--- a/include/iotconnect_telemetry.h
+++ b/include/iotconnect_telemetry.h
@@ -28,7 +28,7 @@ typedef struct IotclMessageHandleTag *IotclMessageHandle;
  * This handle can be used to add data to the message.
  * The handle cannot be re-used and should be destroyed to free up resources, once the message is sent.
  */
-IotclMessageHandle iotcl_telemetry_create();
+IotclMessageHandle iotcl_telemetry_create(void);
 
 /*
  * Destroys the IoTConnect message handle.

--- a/src/iotconnect_common.c
+++ b/src/iotconnect_common.c
@@ -19,7 +19,7 @@ const char *iotcl_to_iso_timestamp(time_t timestamp) {
     return to_iso_timestamp(&timestamp);
 }
 
-const char *iotcl_iso_timestamp_now() {
+const char *iotcl_iso_timestamp_now(void) {
     return to_iso_timestamp(NULL);
 }
 

--- a/src/iotconnect_lib.c
+++ b/src/iotconnect_lib.c
@@ -40,14 +40,14 @@ bool iotcl_init(IotclConfig *c) {
 }
 
 
-IotclConfig *iotcl_get_config() {
+IotclConfig *iotcl_get_config(void) {
     if (!config_is_valid) {
         return NULL;
     }
     return &config;
 }
 
-void iotcl_deinit() {
+void iotcl_deinit(void) {
     config_is_valid = false;
 
     memset(&config, 0, sizeof(config));

--- a/src/iotconnect_telemetry.c
+++ b/src/iotconnect_telemetry.c
@@ -101,7 +101,7 @@ static cJSON *setup_telemetry_object(IotclMessageHandle message) {
     return NULL;
 }
 
-IotclMessageHandle iotcl_telemetry_create() {
+IotclMessageHandle iotcl_telemetry_create(void) {
     cJSON *sdk_array = NULL;
     IotclConfig *config = iotcl_get_config();
     if (!config) return NULL;

--- a/tests/discovery.c
+++ b/tests/discovery.c
@@ -53,7 +53,7 @@ static void report_sync_error(IotclSyncResponse *response, const char* sync_resp
     printf("Raw server response was:\n--------------\n%s\n--------------\n", sync_response_str);
 }
 
-static void test() {
+static void test(void) {
     {
         IotclDiscoveryResponse *dr;
         dr = iotcl_discovery_parse_discovery_response(EXAMPLE_DISCOVERY_RESPONSE);
@@ -97,6 +97,6 @@ static void test() {
     }
 }
 
-int main() {
+int main(void) {
     test();
 }

--- a/tests/event.c
+++ b/tests/event.c
@@ -80,7 +80,7 @@ Command is: ota
 SW Version is: 0.2
 Sent OTA ack: {"mt":11,"t":"2020-07-29T18:15:58.000Z","uniqueId":"my-device-id","cpId":"MyCpid","sdk":{"l":"M_C","v":"2.0","e":"avnetpoc"},"d":{"ackId":"7bd13714-dc07-44ea-99f2-c606f8cf2d2a","msg":"","st":7}}
 */
-void test() {
+static void test(void) {
     IotclConfig config;
     memset(&config, 0, sizeof(config));
 
@@ -103,6 +103,6 @@ void test() {
 }
 
 
-int main() {
+int main(void) {
     test();
 }

--- a/tests/telemetry.c
+++ b/tests/telemetry.c
@@ -16,7 +16,7 @@
 #include "iotconnect_common.h"
 #include "iotconnect_telemetry.h"
 
-void test() {
+static void test(void) {
     IotclConfig config;
 
 
@@ -68,7 +68,7 @@ void p_free(void *ptr) {
     free(ptr);
 }
 
-int main() {
+int main(void) {
     printf("---%d---\n", tracker);
 
     cJSON_Hooks hooks;


### PR DESCRIPTION
I have used a similar version in iotc-generic-c-sdk -- but this is officially untested in this repo.