### PR TITLE
Add casts, so that -Wconversion doesn't fail.

### DIFF
--- a/include/iotconnect_common.h
+++ b/include/iotconnect_common.h
@@ -19,7 +19,7 @@ char *iotcl_strdup(const char *str);
 // NOTE: This function is not thread-safe
 const char *iotcl_iso_timestamp_now(void);
 
-unsigned long get_expiry_from_now(unsigned long int expiry_secs);
+unsigned long get_expiry_from_now(time_t expiry_secs);
 
 #ifdef __cplusplus
 }

--- a/include/iotconnect_common.h
+++ b/include/iotconnect_common.h
@@ -17,13 +17,9 @@ extern "C" {
 char *iotcl_strdup(const char *str);
 
 // NOTE: This function is not thread-safe
-const char *iotcl_to_iso_timestamp(time_t timestamp);
-
-// NOTE: This function is not thread-safe
 const char *iotcl_iso_timestamp_now(void);
 
-// Internal function
-void iotcl_oom_error(void);
+unsigned long get_expiry_from_now(unsigned long int expiry_secs);
 
 #ifdef __cplusplus
 }

--- a/src/iotconnect_common.c
+++ b/src/iotconnect_common.c
@@ -9,18 +9,17 @@
 
 static char timebuf[sizeof "2011-10-08T07:07:01.000Z"];
 
-static const char *to_iso_timestamp(time_t *timestamp) {
-    time_t ts = timestamp ? *timestamp : time(NULL);
+// Obviously, this function is not thread-safe, due to the fixed buffer
+const char *iotcl_iso_timestamp_now(void) {
+    time_t ts = time(NULL);
     strftime(timebuf, (sizeof timebuf), "%Y-%m-%dT%H:%M:%S.000Z", gmtime(&ts));
     return timebuf;
 }
 
-const char *iotcl_to_iso_timestamp(time_t timestamp) {
-    return to_iso_timestamp(&timestamp);
-}
-
-const char *iotcl_iso_timestamp_now(void) {
-    return to_iso_timestamp(NULL);
+unsigned long get_expiry_from_now(unsigned long int expiry_secs)
+{
+    const time_t expiration = time(NULL) + expiry_secs;
+    return (unsigned long) expiration;
 }
 
 char *iotcl_strdup(const char *str) {

--- a/src/iotconnect_common.c
+++ b/src/iotconnect_common.c
@@ -16,7 +16,7 @@ const char *iotcl_iso_timestamp_now(void) {
     return timebuf;
 }
 
-unsigned long get_expiry_from_now(unsigned long int expiry_secs)
+unsigned long get_expiry_from_now(time_t expiry_secs)
 {
     const time_t expiration = time(NULL) + expiry_secs;
     return (unsigned long) expiration;

--- a/src/iotconnect_event.c
+++ b/src/iotconnect_event.c
@@ -166,7 +166,7 @@ char *iotcl_clone_download_url(IotclEventData data, size_t index) {
         return NULL;
     }
     if ((size_t) cJSON_GetArraySize(urls) > index) {
-        cJSON *url = cJSON_GetArrayItem(urls, index);
+        cJSON *url = cJSON_GetArrayItem(urls, (int) index);
         if (is_valid_string(url)) {
             return iotcl_strdup(url->valuestring);
         } else if (cJSON_IsObject(url)) {

--- a/src/iotconnect_telemetry.c
+++ b/src/iotconnect_telemetry.c
@@ -7,6 +7,7 @@
 #include <stddef.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 
 #include "iotconnect_common.h"
@@ -266,16 +267,16 @@ bool iotcl_telemetry_set_null(IotclMessageHandle message, const char *path) {
 const char *iotcl_create_serialized_string(IotclMessageHandle message, bool pretty) {
     const char *serialized_string = NULL;
     if (!message) {
-        PRINTF("message is NULL\n");
+        fprintf(stderr, "message is NULL\n");
         return NULL;
     }
     if (!message->root_value) {
-        PRINTF("message->root_value is NULL\n");
+        fprintf(stderr, "message->root_value is NULL\n");
         return NULL;
     }
     serialized_string = (pretty) ? cJSON_Print(message->root_value) : cJSON_PrintUnformatted(message->root_value);
     if (!serialized_string) {
-        PRINTF("serialized_string is NULL\n");
+        fprintf(stderr, "serialized_string is NULL\n");
         return NULL;
     }
     return serialized_string;


### PR DESCRIPTION
Add get_expiry_from_now() as a helper for SAS generation. Remove unused routines.
Use cJSON_Delete() instead of cJSON_free(), etc.
Add brackets - so can easily add debug to if statements.