### PR TITLE
C2D/OTA Status updates, leak fixes, test improvements

### DIFF
--- a/core/include/iotcl_c2d.h
+++ b/core/include/iotcl_c2d.h
@@ -35,33 +35,22 @@
 #endif
 
 // Command statuses
-
-#ifndef IOTCL_C2D_ACK_USES_SPEC
-#define IOTCL_C2D_EVT_CMD_SUCCESS           7
-#define IOTCL_C2D_EVT_CMD_FAILED            4
-#define IOTCL_C2D_EVT_CMD_SUCCESS_WITH_ACK  7 // Should not be used in most cases
-#else
-/* The specification states different values which differ from the actual values and behavior
- * accepted by the back end. If/when the back end changes to comply with the documentation,
- * define IOTCL_C2D_ACK_USES_SPEC in your iotcl_config.h to use values defined by the documentation.
- */
-#define IOTCL_C2D_EVT_CMD_SUCCESS           0
 #define IOTCL_C2D_EVT_CMD_FAILED            1
 #define IOTCL_C2D_EVT_CMD_SUCCESS_WITH_ACK  2
-#endif
 
 // OTA Download statuses
 // Best practices for OTA status:
-// While the final result of the OTA action should be IOTCL_EVT_OTA_SUCCESS,
-// it can only be determined only if we are certain that we downloaded the OTA and are guaranteed to be successful.
-// A good way to ensure proper result is to send the ack only when the device is up and running OK with the new version.
-// This can be left to the interpretation of the user given the device's capabilities and limitations or the need
-// for fine-grained status.
-#define IOTCL_C2D_EVT_OTA_SUCCESS           0
-#define IOTCL_C2D_EVT_OTA_FAILED            1
-#define IOTCL_C2D_EVT_OTA_DOWNLOADING       2
-#define IOTCL_C2D_EVT_OTA_DOWNLOAD_DONE     3
-#define IOTCL_C2D_EVT_OTA_DOWNLOAD_FAILED   4
+// While the final success of the OTA action should be IOTCL_C2D_EVT_OTA_DOWNLOAD_DONE, it should be generally sent
+// only if we are certain that we downloaded the OTA and the new firmware is up and running successfully.
+// The user can store the original ACK ID and only report success only after successfully running with the new firmware.
+// While the new firmware is downloading over the network or (if available/applicable) flashing, unpacking,
+// self-testing etc. the intermediate fine-grained statuses along with an appropriate message can be reported
+// with the IOTCL_C2D_EVT_OTA_DOWNLOADING status until DONE or FAILED status is reported.
+// The exact steps can be left to the interpretation of the user, given the device's capabilities and limitations.
+#define IOTCL_C2D_EVT_OTA_FAILED            1  // OTA download was not attempted or was rejected
+#define IOTCL_C2D_EVT_OTA_DOWNLOADING       2  // An intermediate step during the firmware update is pending
+#define IOTCL_C2D_EVT_OTA_DOWNLOAD_DONE     3  // OTA download is fully completed. New firmware is up and running.
+#define IOTCL_C2D_EVT_OTA_DOWNLOAD_FAILED   4  // The download itself, self-test, flashing, or unpacking or running the downloaded firmware has failed.
 
 
 #ifdef __cplusplus

--- a/core/include/iotcl_example_config.h
+++ b/core/include/iotcl_example_config.h
@@ -5,17 +5,6 @@
 #ifndef IOTCL_EXAMPLE_CONFIG_H
 #define IOTCL_EXAMPLE_CONFIG_H
 
-/* The specification states different values which differ from the actual values and behavior
- * accepted by the back end. If/when the back end changes to comply with the documentation,
- * define IOTCL_C2D_ACK_USES_SPEC in your iotcl_config.h to use values defined by the documentation.
- */
-// #define IOTCL_C2D_ACK_USES_SPEC
-
-/* Enable this if your discovery response is erroneously reporting that your subscription has expired.
- * Related service ticket https://awspoc.iotconnect.io/support-info/2024031415124727
- */
-// #define IOTCL_DRA_DISCOVERY_IGNORE_SUBSCRIPTION_EXPIRED
-
 // See iotc_log.h for more information about configuring logging
 /*
 #define IOTCL_ENDLN "\r\n"

--- a/core/src/iotcl_c2d.c
+++ b/core/src/iotcl_c2d.c
@@ -170,9 +170,6 @@ static char *iotcl_c2d_create_ack(IotclC2dEventType type, const char *ack_id, in
 
     cJSON *ack_json = cJSON_CreateObject();
     if (!ack_json) goto cleanup;
-#ifndef IOTCL_C2D_ACK_USES_SPEC
-    if (!cJSON_AddStringToObject(ack_json, "t", "2024-00-00T00:00:00.000Z")) goto cleanup;
-#endif
     cJSON *ack_d = cJSON_AddObjectToObject(ack_json, "d");
     if (!ack_d) goto cleanup;
 

--- a/core/src/iotcl_telemetry.c
+++ b/core/src/iotcl_telemetry.c
@@ -148,6 +148,7 @@ static int iotcl_telemetry_set_functions_common(
         cJSON *parent_obj_ptr = cJSON_GetObjectItem(message->current_data_set, object_name);
         if (parent_obj_ptr) {
             if (!cJSON_IsObject(parent_obj_ptr)) {
+                iotcl_free(object_name);
                 IOTCL_ERROR(IOTCL_ERR_BAD_VALUE, "%s: Error: \"%s\" must be an object type and not a value!", function_name, object_name);
                 return IOTCL_ERR_BAD_VALUE;
             }
@@ -174,8 +175,7 @@ IotclMessageHandle iotcl_telemetry_create(void) {
         return NULL; // called function will print the error
     }
 
-    struct IotclMessageHandleTag *message = iotcl_malloc(sizeof(struct IotclMessageHandleTag))
-    ;
+    struct IotclMessageHandleTag *message = iotcl_malloc(sizeof(struct IotclMessageHandleTag));
 
     if (!message) {
         IOTCL_ERROR(IOTCL_ERR_OUT_OF_MEMORY, "iotcl_telemetry_create: Out of memory error while allocating message handle!");
@@ -196,6 +196,7 @@ IotclMessageHandle iotcl_telemetry_create(void) {
     cJSON_Delete(message->root_value);
     message->root_value = NULL;
     message->data_set_array = NULL;
+    iotcl_free(message);
     return NULL;
 }
 

--- a/modules/heap-tracker/heap_tracker.c
+++ b/modules/heap-tracker/heap_tracker.c
@@ -34,7 +34,7 @@ void ht_init() {
     memset(&ht_context, 0, sizeof(ht_context));
 }
 
-int ht_get_num_allocations_on_heap(void) {
+int ht_get_num_current_allocations(void) {
     return ht_context.allocations_on_heap;
 }
 
@@ -66,6 +66,7 @@ void *ht_malloc(size_t size) {
     ht_context.allocations_on_heap++;
     return malloc(size);
 }
+
 
 void ht_free(void *ptr) {
     if (NULL != ptr) {

--- a/tests/unit/device_rest_api.c
+++ b/tests/unit/device_rest_api.c
@@ -83,4 +83,9 @@ int main(void) {
     discovery_test();
 
     ht_print_summary();
+
+    if (ht_get_num_current_allocations() != 0) {
+        return 2;
+    }
+    return 0;
 }

--- a/tests/unit/event.c
+++ b/tests/unit/event.c
@@ -54,7 +54,7 @@ static void on_ota(IotclC2dEventData data) {
     printf("SW version: %s\n", sw_ver);
     printf("HW version: %s\n", hw_ver);
 
-    iotcl_mqtt_send_ota_ack(ack_id, IOTCL_C2D_EVT_OTA_SUCCESS, NULL);
+    iotcl_mqtt_send_ota_ack(ack_id, IOTCL_C2D_EVT_OTA_DOWNLOAD_DONE, NULL);
 
     // try generating a failure
     iotcl_mqtt_send_ota_ack(ack_id, IOTCL_C2D_EVT_OTA_DOWNLOAD_FAILED, NULL);
@@ -99,5 +99,10 @@ int main(void) {
     c2d_test();
 
     ht_print_summary();
+
+    if (ht_get_num_current_allocations() != 0) {
+        return 1;
+    }
+    return 0;
 }
 


### PR DESCRIPTION
@pywtk @MGilhespie @ylin-witekio @wtk-evoirin heads up:

* There is no longer IOTCL_C2D_EVT_CMD_SUCCESS and IOTCL_C2D_EVT_OTA_SUCCESS per how [this IoTConect ticket](https://awspoc.iotconnect.io/support-info/2024031516575173)  has been resolved.
* All of the old workarounds should be removed as well as comments (if any) that were copied from iocl_config files about IOTCL_C2D_ACK_USES_SPEC and IOTCL_DRA_DISCOVERY_IGNORE_SUBSCRIPTION_EXPIRED.
* c-lib submodule should checkout tag v3.1.0-proto-v2.1 and the project should be re-compiled. This tag includes all of the work that we have done with the c-lib fixes so far and I don't think it needs much chrurn in the future.
* The one thing that's left to do is to deal with the issue with fully comparing logic for [iotcl_topics_match_cfg function](https://github.com/avnet-iotconnect/iotc-c-lib/blob/b87ab58b1b353a37c281b48d88197c2245d8f364/core/src/iotcl.c#L22) because when you subscribe to "something/#" the message arrives with topic "something/?name=value&name2=value2" topic so more complex matching would need to be implemented. I will probably remove the logic until we start implementing Twins/Shadow, so we can deal with it then. For now, you are fine if (and mostlikely you are) using the [iotcl_c2d_process_event funciton](https://github.com/avnet-iotconnect/iotc-c-lib/blob/b87ab58b1b353a37c281b48d88197c2245d8f364/core/include/iotcl_c2d.h#L78)

EDIT: TLDR summary:
* pull tag 3.1.0-proto-v2.1 in your submodule
* Remove references and comments pertaining to IOTCL_C2D_ACK_USES_SPEC and IOTCL_DRA_DISCOVERY_IGNORE_SUBSCRIPTION_EXPIRED in config files.
* To remove SUCCES status, in summary:  
  * If using SUCCESS for command acks, use SUCCESS_WITH_ACK.
  * If using SUCCESS for ota ACKs, useDOWNLOAD_DONE
